### PR TITLE
Add do_not_translate_phrases to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ai_translation:
   provider: anthropic # options: anthropic | openai
   model: claude-haiku-4-5
   api_key_env: ANTHROPIC_API_KEY_INTL_AI
-  ignore: # words to keep untranslated (e.g. brand names)
+  do_not_translate_phrases:
     - "DeepTime"
     - "Flutter"
   context: "A productivity and focus timer app for deep work sessions"


### PR DESCRIPTION
## Summary
- Replaces `ignore` with `do_not_translate_phrases` in the README example config
- Removes the now-redundant inline comment since the parameter name is self-explanatory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolves #39 