### PR TITLE
Preserve template ARB key ordering in merged output

### DIFF
--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -202,8 +202,13 @@ class Translator {
     required ArbFile template,
     required Map<String, String> newTranslations,
   }) {
-    final mergedEntries = Map<String, String>.from(existingArbFile.entries)
-      ..addAll(newTranslations);
+    final mergedEntries = <String, String>{
+      for (final key in template.entries.keys)
+        if (newTranslations.containsKey(key))
+          key: newTranslations[key]!
+        else if (existingArbFile.entries.containsKey(key))
+          key: existingArbFile.entries[key]!,
+    };
 
     final mergedMetadata = _mergeMetadata(
       existingMetadata: existingArbFile.metadata,

--- a/test/translator_test.dart
+++ b/test/translator_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:intl_ai/src/config/ai_translation_config.dart';
@@ -124,6 +125,48 @@ ai_translation:
         ),
       ).called(1);
     });
+
+    test(
+      'preserves template key order when new key inserted in middle',
+      () async {
+        File(p.join(arbDir.path, 'app_en.arb')).writeAsStringSync('''
+{
+  "@@locale": "en",
+  "appTitle": "Deep Work Timer",
+  "greet": "Hello",
+  "cancel": "Cancel"
+}
+''');
+
+        when(
+          () => mockRepository.getTranslations(
+            keys: {'greet': 'Hello', 'cancel': 'Cancel'},
+            sourceLocale: 'en',
+            targetLocale: 'de',
+            config: any(named: 'config'),
+          ),
+        ).thenAnswer(
+          (_) async => {'greet': 'Hallo', 'cancel': 'Abbrechen'},
+        );
+
+        final translator = Translator(
+          config: config,
+          projectRoot: tempDir.path,
+          repository: mockRepository,
+        );
+
+        await translator.translateLocales();
+
+        final deContent = File(
+          p.join(arbDir.path, 'app_de.arb'),
+        ).readAsStringSync();
+        final decoded = jsonDecode(deContent) as Map<String, dynamic>;
+        final entryKeys = decoded.keys
+            .where((k) => !k.startsWith('@'))
+            .toList();
+        expect(entryKeys, equals(['appTitle', 'greet', 'cancel']));
+      },
+    );
 
     test('dry-run mode does not write ARB files', () async {
       when(


### PR DESCRIPTION
## Summary
- Rebuilds merged ARB entries in template key order so new keys land in their template position instead of being appended at the end, eliminating noisy diffs when keys are inserted in the middle of the template.
- Keys present in an existing target file but absent from the template are dropped (template becomes the source of truth for both content and order).
- Metadata handling is unchanged.

Resolves #22.

## Test plan
- [x] `fvm dart test` — all tests pass, including new `preserves template key order when new key inserted in middle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)