### PR TITLE
fix: include doNotTranslatePhrases in AiTranslationConfig equality

### DIFF
--- a/lib/src/config/ai_translation_config.dart
+++ b/lib/src/config/ai_translation_config.dart
@@ -62,16 +62,32 @@ class AiTranslationConfig {
   final String? context;
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is AiTranslationConfig &&
-          provider == other.provider &&
-          model == other.model &&
-          apiKeyEnv == other.apiKeyEnv &&
-          context == other.context;
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! AiTranslationConfig) return false;
+    if (provider != other.provider) return false;
+    if (model != other.model) return false;
+    if (apiKeyEnv != other.apiKeyEnv) return false;
+    if (context != other.context) return false;
+    if (doNotTranslatePhrases.length != other.doNotTranslatePhrases.length) {
+      return false;
+    }
+    for (var i = 0; i < doNotTranslatePhrases.length; i++) {
+      if (doNotTranslatePhrases[i] != other.doNotTranslatePhrases[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   @override
-  int get hashCode => Object.hash(provider, model, apiKeyEnv, context);
+  int get hashCode => Object.hash(
+    provider,
+    model,
+    apiKeyEnv,
+    context,
+    Object.hashAll(doNotTranslatePhrases),
+  );
 }
 
 enum AiTranslationProvider {

--- a/test/config/ai_translation_config_test.dart
+++ b/test/config/ai_translation_config_test.dart
@@ -84,4 +84,138 @@ void main() {
       );
     });
   });
+
+  group('AiTranslationConfig equality', () {
+    const baseConfig = AiTranslationConfig(
+      provider: AiTranslationProvider.openai,
+      model: 'gpt-4.1-mini',
+      apiKeyEnv: 'OPENAI_API_KEY',
+      doNotTranslatePhrases: ['Deep Work', 'Flutter'],
+      context: 'A focus timer app',
+    );
+
+    test('identical instances are equal', () {
+      expect(baseConfig, equals(baseConfig));
+    });
+
+    test('instances with identical field values are equal', () {
+      final phrases = <String>['Deep Work', 'Flutter'];
+      final other = AiTranslationConfig(
+        provider: AiTranslationProvider.openai,
+        model: 'gpt-4.1-mini',
+        apiKeyEnv: 'OPENAI_API_KEY',
+        doNotTranslatePhrases: phrases,
+        context: 'A focus timer app',
+      );
+      expect(identical(baseConfig, other), isFalse);
+      expect(baseConfig, equals(other));
+      expect(baseConfig.hashCode, other.hashCode);
+    });
+
+    test('differs in provider', () {
+      const other = AiTranslationConfig(
+        provider: AiTranslationProvider.anthropic,
+        model: 'gpt-4.1-mini',
+        apiKeyEnv: 'OPENAI_API_KEY',
+        doNotTranslatePhrases: ['Deep Work', 'Flutter'],
+        context: 'A focus timer app',
+      );
+      expect(baseConfig, isNot(equals(other)));
+    });
+
+    test('differs in model', () {
+      const other = AiTranslationConfig(
+        provider: AiTranslationProvider.openai,
+        model: 'gpt-4o',
+        apiKeyEnv: 'OPENAI_API_KEY',
+        doNotTranslatePhrases: ['Deep Work', 'Flutter'],
+        context: 'A focus timer app',
+      );
+      expect(baseConfig, isNot(equals(other)));
+    });
+
+    test('differs in apiKeyEnv', () {
+      const other = AiTranslationConfig(
+        provider: AiTranslationProvider.openai,
+        model: 'gpt-4.1-mini',
+        apiKeyEnv: 'OTHER_KEY',
+        doNotTranslatePhrases: ['Deep Work', 'Flutter'],
+        context: 'A focus timer app',
+      );
+      expect(baseConfig, isNot(equals(other)));
+    });
+
+    test('differs in context', () {
+      const otherWithDifferentContext = AiTranslationConfig(
+        provider: AiTranslationProvider.openai,
+        model: 'gpt-4.1-mini',
+        apiKeyEnv: 'OPENAI_API_KEY',
+        doNotTranslatePhrases: ['Deep Work', 'Flutter'],
+        context: 'A different app',
+      );
+      const otherWithNullContext = AiTranslationConfig(
+        provider: AiTranslationProvider.openai,
+        model: 'gpt-4.1-mini',
+        apiKeyEnv: 'OPENAI_API_KEY',
+        doNotTranslatePhrases: ['Deep Work', 'Flutter'],
+      );
+      expect(baseConfig, isNot(equals(otherWithDifferentContext)));
+      expect(baseConfig, isNot(equals(otherWithNullContext)));
+    });
+
+    test('differs in doNotTranslatePhrases contents', () {
+      const other = AiTranslationConfig(
+        provider: AiTranslationProvider.openai,
+        model: 'gpt-4.1-mini',
+        apiKeyEnv: 'OPENAI_API_KEY',
+        doNotTranslatePhrases: ['Deep Work', 'Dart'],
+        context: 'A focus timer app',
+      );
+      expect(baseConfig, isNot(equals(other)));
+      expect(baseConfig.hashCode, isNot(other.hashCode));
+    });
+
+    test('differs in doNotTranslatePhrases length', () {
+      const other = AiTranslationConfig(
+        provider: AiTranslationProvider.openai,
+        model: 'gpt-4.1-mini',
+        apiKeyEnv: 'OPENAI_API_KEY',
+        doNotTranslatePhrases: ['Deep Work'],
+        context: 'A focus timer app',
+      );
+      expect(baseConfig, isNot(equals(other)));
+    });
+
+    test('differs in doNotTranslatePhrases order', () {
+      const other = AiTranslationConfig(
+        provider: AiTranslationProvider.openai,
+        model: 'gpt-4.1-mini',
+        apiKeyEnv: 'OPENAI_API_KEY',
+        doNotTranslatePhrases: ['Flutter', 'Deep Work'],
+        context: 'A focus timer app',
+      );
+      expect(baseConfig, isNot(equals(other)));
+    });
+
+    test('equal doNotTranslatePhrases from different list instances', () {
+      final phrasesA = <String>['Deep Work', 'Flutter'];
+      final phrasesB = <String>['Deep Work', 'Flutter'];
+      final a = AiTranslationConfig(
+        provider: AiTranslationProvider.openai,
+        model: 'gpt-4.1-mini',
+        apiKeyEnv: 'OPENAI_API_KEY',
+        doNotTranslatePhrases: phrasesA,
+        context: 'A focus timer app',
+      );
+      final b = AiTranslationConfig(
+        provider: AiTranslationProvider.openai,
+        model: 'gpt-4.1-mini',
+        apiKeyEnv: 'OPENAI_API_KEY',
+        doNotTranslatePhrases: phrasesB,
+        context: 'A focus timer app',
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- `AiTranslationConfig.==` and `hashCode` now include `doNotTranslatePhrases` — two configs differing only in the ignore-list previously compared equal and shared a hash.
- Equality compares the list element-wise (order-sensitive); `hashCode` folds in `Object.hashAll(doNotTranslatePhrases)`.
- No new dependencies.

## Test plan

- [x] `fvm dart test` — 104/104 passing (11 new cases in `AiTranslationConfig equality` group covering identity, value equality, every field difference, list contents/length/order, and equality across distinct list instances).
- [x] `fvm dart analyze` — no issues.
- [x] `fvm dart format --set-exit-if-changed .` — clean.

Resolves #28