### PR TITLE
fix: parse compound locales from ARB filenames

### DIFF
--- a/lib/src/arb_file.dart
+++ b/lib/src/arb_file.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:intl_ai/src/utils.dart';
 import 'package:path/path.dart' as p;
 
 class ArbFile {
@@ -68,9 +69,6 @@ class ArbFile {
     File(path).writeAsStringSync('{\n${lines.join(',\n')}\n}\n');
   }
 
-  static String _localeFromFilename(String basename) {
-    final name = p.basenameWithoutExtension(basename);
-    final parts = name.split('_');
-    return parts.last;
-  }
+  static String _localeFromFilename(String basename) =>
+      parseLocaleFromFilename(basename).locale;
 }

--- a/lib/src/config/l10n_config.dart
+++ b/lib/src/config/l10n_config.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:intl_ai/src/config/ai_translation_config.dart';
+import 'package:intl_ai/src/utils.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
@@ -64,15 +65,7 @@ class L10nConfig {
   final String outputLocalizationFile;
   final AiTranslationConfig aiTranslationConfig;
 
-  String get templateLocale {
-    final name = p.basenameWithoutExtension(templateArbFile);
-    final parts = name.split('_');
-    return parts.last;
-  }
+  String get templateLocale => parseLocaleFromFilename(templateArbFile).locale;
 
-  String get arbPrefix {
-    final name = p.basenameWithoutExtension(templateArbFile);
-    final parts = name.split('_');
-    return parts.sublist(0, parts.length - 1).join('_');
-  }
+  String get arbPrefix => parseLocaleFromFilename(templateArbFile).prefix;
 }

--- a/lib/src/locale_validator.dart
+++ b/lib/src/locale_validator.dart
@@ -1,19 +1,8 @@
-import 'package:intl_ai/src/cldr_locales.dart';
 import 'package:intl_ai/src/utils.dart';
 
 enum LocaleStatus { knownCldr, unknown }
 
 class LocaleValidator {
-  static LocaleStatus validate(String locale) {
-    final canonical = canonicalizeLocale(locale);
-    if (kKnownCldrLocales.contains(canonical)) return LocaleStatus.knownCldr;
-
-    final parts = canonical.split('_');
-    for (var i = parts.length - 1; i >= 1; i--) {
-      final prefix = parts.sublist(0, i).join('_');
-      if (kKnownCldrLocales.contains(prefix)) return LocaleStatus.knownCldr;
-    }
-
-    return LocaleStatus.unknown;
-  }
+  static LocaleStatus validate(String locale) =>
+      isKnownCldrLocale(locale) ? LocaleStatus.knownCldr : LocaleStatus.unknown;
 }

--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -7,6 +7,7 @@ import 'package:intl_ai/src/dry_run_manager.dart';
 import 'package:intl_ai/src/intl_ai_exception.dart';
 import 'package:intl_ai/src/locale_validator.dart';
 import 'package:intl_ai/src/repositories/translation_repository.dart';
+import 'package:intl_ai/src/utils.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
@@ -279,10 +280,7 @@ class Translator {
     }
 
     final templateBasename = p.basename(config.templateArbFile);
-    final templateName = p.basenameWithoutExtension(templateBasename);
-    final parts = templateName.split('_');
-    final prefix = parts.sublist(0, parts.length - 1).join('_');
-    final templateLocale = parts.last;
+    final templateParsed = parseLocaleFromFilename(templateBasename);
 
     final locales = <String>[];
     for (final entity in dir.listSync()) {
@@ -291,13 +289,11 @@ class Translator {
       if (!basename.endsWith('.arb')) continue;
       if (basename == templateBasename) continue;
 
-      final name = p.basenameWithoutExtension(basename);
-      if (!name.startsWith('${prefix}_')) continue;
+      final parsed = parseLocaleFromFilename(basename);
+      if (parsed.prefix != templateParsed.prefix) continue;
+      if (parsed.locale == templateParsed.locale) continue;
 
-      final locale = name.substring(prefix.length + 1);
-      if (locale.isNotEmpty && locale != templateLocale) {
-        locales.add(locale);
-      }
+      locales.add(parsed.locale);
     }
 
     return locales..sort();

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:intl_ai/src/cldr_locales.dart';
 import 'package:path/path.dart' as p;
 
 String? getConfigDirectory() {
@@ -15,3 +16,36 @@ String? getConfigDirectory() {
 
 String canonicalizeLocale(String locale) =>
     locale.replaceAll('-', '_').toLowerCase();
+
+({String prefix, String locale}) parseLocaleFromFilename(String filename) {
+  final name = p.basenameWithoutExtension(filename);
+  final parts = name.split('_');
+
+  for (var i = 0; i < parts.length; i++) {
+    final candidate = parts.sublist(i).join('_');
+    if (isKnownCldrLocale(candidate)) {
+      return (
+        prefix: parts.sublist(0, i).join('_'),
+        locale: candidate,
+      );
+    }
+  }
+
+  return (
+    prefix: parts.sublist(0, parts.length - 1).join('_'),
+    locale: parts.last,
+  );
+}
+
+bool isKnownCldrLocale(String locale) {
+  final canonical = canonicalizeLocale(locale);
+  if (kKnownCldrLocales.contains(canonical)) return true;
+
+  final parts = canonical.split('_');
+  for (var i = parts.length - 1; i >= 1; i--) {
+    final prefix = parts.sublist(0, i).join('_');
+    if (kKnownCldrLocales.contains(prefix)) return true;
+  }
+
+  return false;
+}

--- a/test/arb_file_test.dart
+++ b/test/arb_file_test.dart
@@ -55,6 +55,18 @@ void main() {
         throwsA(isA<FormatException>()),
       );
     });
+
+    test('derives compound locale from filename when @@locale missing', () {
+      final path = p.join(testDirectory.path, 'app_zh_Hans.arb');
+      File(path).writeAsStringSync('''
+{
+  "appTitle": "Deep Work Timer"
+}
+''');
+
+      final arb = ArbFile.fromFile(path);
+      expect(arb.locale, 'zh_Hans');
+    });
   });
 
   group('ArbFile.writeToFile', () {

--- a/test/config/l10n_config_test.dart
+++ b/test/config/l10n_config_test.dart
@@ -59,6 +59,34 @@ ai_translation:
       expect(config.arbPrefix, 'app');
     });
 
+    test('templateLocale derived from compound script template', () {
+      writeYaml('''
+template-arb-file: app_zh_Hans.arb
+ai_translation:
+  provider: openai
+  model: gpt-4
+  api_key_env: KEY
+''');
+
+      final config = L10nConfig.load(tempDir.path);
+      expect(config.templateLocale, 'zh_Hans');
+      expect(config.arbPrefix, 'app');
+    });
+
+    test('templateLocale derived from country-code template', () {
+      writeYaml('''
+template-arb-file: app_pt_BR.arb
+ai_translation:
+  provider: openai
+  model: gpt-4
+  api_key_env: KEY
+''');
+
+      final config = L10nConfig.load(tempDir.path);
+      expect(config.templateLocale, 'pt_BR');
+      expect(config.arbPrefix, 'app');
+    });
+
     test('defaults arb-dir when not set', () {
       writeYaml('''
 ai_translation:

--- a/test/translator_test.dart
+++ b/test/translator_test.dart
@@ -202,6 +202,94 @@ ai_translation:
       );
     });
 
+    test(
+      'compound template detects simple and compound target locales',
+      () async {
+        File(p.join(tempDir.path, 'l10n.yaml')).writeAsStringSync('''
+arb-dir: lib/l10n
+template-arb-file: app_zh_Hans.arb
+output-localization-file: app_localizations.dart
+ai_translation:
+  provider: openai
+  model: gpt-4.1-mini
+  api_key_env: TEST_KEY
+''');
+        File(p.join(arbDir.path, 'app_en.arb')).deleteSync();
+        File(p.join(arbDir.path, 'app_de.arb')).deleteSync();
+
+        File(p.join(arbDir.path, 'app_zh_Hans.arb')).writeAsStringSync('''
+{
+  "@@locale": "zh_Hans",
+  "appTitle": "深度工作计时器"
+}
+''');
+        File(p.join(arbDir.path, 'app_en.arb')).writeAsStringSync('''
+{
+  "@@locale": "en"
+}
+''');
+        File(p.join(arbDir.path, 'app_pt_BR.arb')).writeAsStringSync('''
+{
+  "@@locale": "pt_BR"
+}
+''');
+
+        final compoundConfig = L10nConfig.load(tempDir.path);
+
+        when(
+          () => mockRepository.getTranslations(
+            keys: any(named: 'keys'),
+            sourceLocale: 'zh_Hans',
+            targetLocale: 'en',
+            config: any(named: 'config'),
+          ),
+        ).thenAnswer((_) async => {'appTitle': 'Deep Work Timer'});
+
+        when(
+          () => mockRepository.getTranslations(
+            keys: any(named: 'keys'),
+            sourceLocale: 'zh_Hans',
+            targetLocale: 'pt_BR',
+            config: any(named: 'config'),
+          ),
+        ).thenAnswer((_) async => {'appTitle': 'Cronômetro de Trabalho'});
+
+        final translator = Translator(
+          config: compoundConfig,
+          projectRoot: tempDir.path,
+          repository: mockRepository,
+        );
+
+        await translator.translateLocales();
+
+        verify(
+          () => mockRepository.getTranslations(
+            keys: any(named: 'keys'),
+            sourceLocale: 'zh_Hans',
+            targetLocale: 'en',
+            config: any(named: 'config'),
+          ),
+        ).called(1);
+        verify(
+          () => mockRepository.getTranslations(
+            keys: any(named: 'keys'),
+            sourceLocale: 'zh_Hans',
+            targetLocale: 'pt_BR',
+            config: any(named: 'config'),
+          ),
+        ).called(1);
+
+        expect(
+          File(p.join(arbDir.path, 'app_en.arb')).readAsStringSync(),
+          contains('Deep Work Timer'),
+        );
+        expect(
+          File(p.join(arbDir.path, 'app_pt_BR.arb')).readAsStringSync(),
+          contains('Cronômetro'),
+        );
+      },
+    );
+
     test('locale flag translates only specified locale', () async {
       File(p.join(arbDir.path, 'app_fr.arb')).writeAsStringSync('''
 {

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -17,4 +17,89 @@ void main() {
       expect(canonicalizeLocale('zh_hans'), equals('zh_hans'));
     });
   });
+
+  group('parseLocaleFromFilename', () {
+    void expectParse(
+      String filename, {
+      required String prefix,
+      required String locale,
+    }) {
+      final result = parseLocaleFromFilename(filename);
+      expect(
+        result.prefix,
+        equals(prefix),
+        reason: 'prefix for $filename',
+      );
+      expect(
+        result.locale,
+        equals(locale),
+        reason: 'locale for $filename',
+      );
+    }
+
+    test('simple language', () {
+      expectParse('app_en.arb', prefix: 'app', locale: 'en');
+    });
+
+    test('country code', () {
+      expectParse('app_en_US.arb', prefix: 'app', locale: 'en_US');
+      expectParse('app_pt_BR.arb', prefix: 'app', locale: 'pt_BR');
+    });
+
+    test('numeric region', () {
+      expectParse('app_es_419.arb', prefix: 'app', locale: 'es_419');
+    });
+
+    test('script', () {
+      expectParse('app_zh_Hans.arb', prefix: 'app', locale: 'zh_Hans');
+    });
+
+    test('full compound', () {
+      expectParse(
+        'app_zh_Hans_CN.arb',
+        prefix: 'app',
+        locale: 'zh_Hans_CN',
+      );
+    });
+
+    test('hyphen inside a segment resolves via canonicalization', () {
+      expectParse('app_zh-Hans.arb', prefix: 'app', locale: 'zh-Hans');
+    });
+
+    test('multi-word prefix', () {
+      expectParse(
+        'intl_messages_en.arb',
+        prefix: 'intl_messages',
+        locale: 'en',
+      );
+    });
+
+    test('no prefix', () {
+      expectParse('en.arb', prefix: '', locale: 'en');
+      expectParse('zh_Hans.arb', prefix: '', locale: 'zh_Hans');
+    });
+
+    test('unknown locale falls back to last segment', () {
+      expectParse('app_xyz.arb', prefix: 'app', locale: 'xyz');
+    });
+
+    test('no underscore falls back to whole name', () {
+      expectParse('messages.arb', prefix: '', locale: 'messages');
+    });
+
+    test('preserves original casing', () {
+      expectParse('app_zh_Hans.arb', prefix: 'app', locale: 'zh_Hans');
+      expectParse('app_pt_BR.arb', prefix: 'app', locale: 'pt_BR');
+      expectParse(
+        'app_sr_Latn_RS.arb',
+        prefix: 'app',
+        locale: 'sr_Latn_RS',
+      );
+    });
+
+    test('strips file extension', () {
+      expectParse('app_en', prefix: 'app', locale: 'en');
+      expectParse('app_en.arb', prefix: 'app', locale: 'en');
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Adds a CLDR-aware `parseLocaleFromFilename` helper in `lib/src/utils.dart` that finds the longest filename suffix matching a known CLDR locale, preserving original casing.
- Wires the helper into `L10nConfig.templateLocale`/`arbPrefix`, `ArbFile._localeFromFilename`, and `Translator._detectTargetLocales` so compound locales (`zh_Hans`, `pt_BR`, `es_419`, `zh_Hans_CN`) are split correctly into prefix and locale.
- Promotes the CLDR membership check (canonical lookup + longest known prefix) to a shared `isKnownCldrLocale` helper that `LocaleValidator` now delegates to, eliminating duplicated logic.

Before, `app_zh_Hans.arb` parsed to `(prefix: app_zh, locale: Hans)`, which broke the AI prompt's `sourceLocale`, target enumeration, and output filename generation.

Closes #16.

## Test plan
- [x] `test/utils_test.dart`: 12 new cases for `parseLocaleFromFilename` covering simple, country, numeric region, script, full compound, hyphen-in-segment, multi-word prefix, no prefix, unknown fallback, no underscore, original casing, and extension stripping.
- [x] `test/config/l10n_config_test.dart`: new cases for compound script (`app_zh_Hans.arb`) and country-code (`app_pt_BR.arb`) templates.
- [x] `test/arb_file_test.dart`: new case where `@@locale` is missing and the filename is compound.
- [x] `test/translator_test.dart`: new case where the template is `app_zh_Hans.arb` and target files include simple (`app_en.arb`) and compound (`app_pt_BR.arb`) locales.
- [x] `fvm dart format --set-exit-if-changed .` clean
- [x] `fvm dart analyze` clean
- [x] `fvm dart test` — 110 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)