### PR TITLE
feat: bound HTTP request time with 3-minute per-attempt timeout

### DIFF
--- a/lib/src/repositories/anthropic_repository.dart
+++ b/lib/src/repositories/anthropic_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -21,6 +22,7 @@ class AnthropicRepository implements TranslationRepository {
   static const _endpoint = 'https://api.anthropic.com/v1/messages';
   static const _anthropicVersion = '2023-06-01';
   static const _maxRetries = 3;
+  static const _requestTimeout = Duration(minutes: 3);
   static const _retryDelays = [
     Duration(seconds: 1),
     Duration(seconds: 4),
@@ -64,15 +66,28 @@ class AnthropicRepository implements TranslationRepository {
 
     http.Response? response;
     for (var attempt = 0; attempt < _maxRetries; attempt++) {
-      response = await _client.post(
-        Uri.parse(_endpoint),
-        headers: {
-          'x-api-key': apiKey,
-          'anthropic-version': _anthropicVersion,
-          'Content-Type': 'application/json',
-        },
-        body: body,
-      );
+      try {
+        response = await _client
+            .post(
+              Uri.parse(_endpoint),
+              headers: {
+                'x-api-key': apiKey,
+                'anthropic-version': _anthropicVersion,
+                'Content-Type': 'application/json',
+              },
+              body: body,
+            )
+            .timeout(_requestTimeout);
+      } on TimeoutException {
+        if (attempt == _maxRetries - 1) {
+          throw IntlAiException(
+            'Anthropic request timed out after $_maxRetries attempts of '
+            '${_requestTimeout.inMinutes} minutes each.',
+          );
+        }
+        await Future<void>.delayed(_retryDelays[attempt]);
+        continue;
+      }
 
       if (response.statusCode == 200) break;
 

--- a/lib/src/repositories/openai_repository.dart
+++ b/lib/src/repositories/openai_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -20,6 +21,7 @@ class OpenAiRepository implements TranslationRepository {
 
   static const _endpoint = 'https://api.openai.com/v1/chat/completions';
   static const _maxRetries = 3;
+  static const _requestTimeout = Duration(minutes: 3);
   static const _retryDelays = [
     Duration(seconds: 1),
     Duration(seconds: 4),
@@ -63,14 +65,27 @@ class OpenAiRepository implements TranslationRepository {
 
     http.Response? response;
     for (var attempt = 0; attempt < _maxRetries; attempt++) {
-      response = await _client.post(
-        Uri.parse(_endpoint),
-        headers: {
-          'Authorization': 'Bearer $apiKey',
-          'Content-Type': 'application/json',
-        },
-        body: body,
-      );
+      try {
+        response = await _client
+            .post(
+              Uri.parse(_endpoint),
+              headers: {
+                'Authorization': 'Bearer $apiKey',
+                'Content-Type': 'application/json',
+              },
+              body: body,
+            )
+            .timeout(_requestTimeout);
+      } on TimeoutException {
+        if (attempt == _maxRetries - 1) {
+          throw IntlAiException(
+            'OpenAI request timed out after $_maxRetries attempts of '
+            '${_requestTimeout.inMinutes} minutes each.',
+          );
+        }
+        await Future<void>.delayed(_retryDelays[attempt]);
+        continue;
+      }
 
       if (response.statusCode == 200) break;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   yaml: ^3.1.3
 
 dev_dependencies:
+  fake_async: ^1.3.1
   mocktail: ^1.0.4
   test: ^1.25.15
   very_good_analysis: ^10.2.0

--- a/test/repositories/anthropic_repository_test.dart
+++ b/test/repositories/anthropic_repository_test.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:convert';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl_ai/src/config/ai_translation_config.dart';
 import 'package:intl_ai/src/intl_ai_exception.dart';
@@ -209,6 +211,86 @@ void main() {
           ),
         ),
       );
+    });
+
+    test('retries once on TimeoutException then returns translations', () {
+      final translations = {'hello': 'Bonjour'};
+      final successBody = jsonEncode({
+        'content': [
+          {'text': jsonEncode(translations)},
+        ],
+      });
+
+      var call = 0;
+      when(
+        () => mockClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer((_) async {
+        call++;
+        if (call == 1) {
+          throw TimeoutException('timed out');
+        }
+        return http.Response(successBody, 200);
+      });
+
+      final repository = makeRepository();
+
+      fakeAsync((async) {
+        Map<String, String>? result;
+        unawaited(
+          repository
+              .getTranslations(
+                keys: {'hello': 'Hello'},
+                sourceLocale: 'en',
+                targetLocale: 'fr',
+                config: config,
+              )
+              .then((value) => result = value),
+        );
+        async.elapse(const Duration(seconds: 2));
+
+        expect(result!['hello'], 'Bonjour');
+        expect(call, 2);
+      });
+    });
+
+    test('throws IntlAiException after all retries time out', () {
+      when(
+        () => mockClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer((_) async => throw TimeoutException('timed out'));
+
+      final repository = makeRepository();
+
+      fakeAsync((async) {
+        Object? error;
+        unawaited(
+          repository
+              .getTranslations(
+                keys: {'hello': 'Hello'},
+                sourceLocale: 'en',
+                targetLocale: 'fr',
+                config: config,
+              )
+              .catchError((Object e) {
+                error = e;
+                return <String, String>{};
+              }),
+        );
+        async.elapse(const Duration(seconds: 30));
+
+        expect(error, isA<IntlAiException>());
+        expect(
+          (error! as IntlAiException).message,
+          allOf(contains('timed out after'), contains('Anthropic')),
+        );
+      });
     });
   });
 }

--- a/test/repositories/openai_repository_test.dart
+++ b/test/repositories/openai_repository_test.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:convert';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl_ai/src/config/ai_translation_config.dart';
 import 'package:intl_ai/src/intl_ai_exception.dart';
@@ -258,5 +260,87 @@ void main() {
         );
       },
     );
+
+    test('retries once on TimeoutException then returns translations', () {
+      final translations = {'hello': 'Hallo'};
+      final successBody = jsonEncode({
+        'choices': [
+          {
+            'message': {'content': jsonEncode(translations)},
+          },
+        ],
+      });
+
+      var call = 0;
+      when(
+        () => mockClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer((_) async {
+        call++;
+        if (call == 1) {
+          throw TimeoutException('timed out');
+        }
+        return http.Response(successBody, 200);
+      });
+
+      final repository = makeRepository();
+
+      fakeAsync((async) {
+        Map<String, String>? result;
+        unawaited(
+          repository
+              .getTranslations(
+                keys: {'hello': 'Hello'},
+                sourceLocale: 'en',
+                targetLocale: 'de',
+                config: config,
+              )
+              .then((value) => result = value),
+        );
+        async.elapse(const Duration(seconds: 2));
+
+        expect(result!['hello'], 'Hallo');
+        expect(call, 2);
+      });
+    });
+
+    test('throws $IntlAiException after all retries time out', () {
+      when(
+        () => mockClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer((_) async => throw TimeoutException('timed out'));
+
+      final repository = makeRepository();
+
+      fakeAsync((async) {
+        Object? error;
+        unawaited(
+          repository
+              .getTranslations(
+                keys: {'hello': 'Hello'},
+                sourceLocale: 'en',
+                targetLocale: 'de',
+                config: config,
+              )
+              .catchError((Object e) {
+                error = e;
+                return <String, String>{};
+              }),
+        );
+        async.elapse(const Duration(seconds: 30));
+
+        expect(error, isA<IntlAiException>());
+        expect(
+          (error! as IntlAiException).message,
+          allOf(contains('timed out after'), contains('OpenAI')),
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Wraps `http.Client.post(...)` calls in `OpenAiRepository` and `AnthropicRepository` with `.timeout(Duration(minutes: 3))` so a stalled connection no longer hangs the CLI indefinitely.
- Catches `TimeoutException` inside the existing retry loop (alongside 429/5xx), reusing the same 1s/4s/16s backoff. After `_maxRetries` consecutive timeouts, surfaces an `IntlAiException` whose message names the timeout so it is distinguishable from an HTTP error.
- No public API or config changes. Adds `fake_async` to `dev_dependencies` so the exhaustion tests can fast-forward the 21s of backoff.

Closes #23.

## Plan

[docs/plan/2026-05-12-feat-http-request-timeout-plan.md](docs/plan/2026-05-12-feat-http-request-timeout-plan.md)

## Test plan

- [ ] `fvm dart format --set-exit-if-changed .` passes
- [ ] `fvm dart analyze` passes
- [ ] `fvm dart test` passes (98 tests, including 4 new timeout tests — one retry-then-success and one all-timeouts-exhaust path per repository)
- [ ] Inspect both `post` call sites are wrapped with `.timeout(_requestTimeout)` and the `on TimeoutException` block sits inside the existing `for` loop
- [ ] Optional manual check: point the CLI at an unreachable host and confirm it fails with the new `IntlAiException` after ~9 minutes instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)