### PR TITLE
refactor: deduplicate _getParsedResponse across translation repositories

### DIFF
--- a/lib/src/repositories/anthropic_repository.dart
+++ b/lib/src/repositories/anthropic_repository.dart
@@ -92,7 +92,7 @@ class AnthropicRepository implements TranslationRepository {
     final firstBlock = contentList[0] as Map<String, dynamic>;
     final content = firstBlock['text'] as String;
 
-    return _getParsedResponse(content);
+    return TranslationRepository.parseTranslationsJson(content);
   }
 
   @override
@@ -106,23 +106,5 @@ class AnthropicRepository implements TranslationRepository {
         'Consider using a model with higher output limits.',
       );
     }
-  }
-
-  Map<String, String> _getParsedResponse(String content) {
-    var cleanedContent = content.trim();
-    if (cleanedContent.startsWith('```')) {
-      final firstNewline = cleanedContent.indexOf('\n');
-      if (firstNewline != -1) {
-        cleanedContent = cleanedContent.substring(firstNewline + 1);
-      }
-      if (cleanedContent.endsWith('```')) {
-        cleanedContent = cleanedContent
-            .substring(0, cleanedContent.length - 3)
-            .trim();
-      }
-    }
-
-    final decoded = jsonDecode(cleanedContent) as Map<String, dynamic>;
-    return decoded.map((k, v) => MapEntry(k, v.toString()));
   }
 }

--- a/lib/src/repositories/openai_repository.dart
+++ b/lib/src/repositories/openai_repository.dart
@@ -91,7 +91,7 @@ class OpenAiRepository implements TranslationRepository {
     final message = firstChoice['message'] as Map<String, dynamic>;
     final content = message['content'] as String;
 
-    return _getParsedResponse(content);
+    return TranslationRepository.parseTranslationsJson(content);
   }
 
   @override
@@ -112,23 +112,5 @@ class OpenAiRepository implements TranslationRepository {
         'The source text may contain content that triggers safety filters.',
       );
     }
-  }
-
-  Map<String, String> _getParsedResponse(String content) {
-    var cleanedContent = content.trim();
-    if (cleanedContent.startsWith('```')) {
-      final firstNewline = cleanedContent.indexOf('\n');
-      if (firstNewline != -1) {
-        cleanedContent = cleanedContent.substring(firstNewline + 1);
-      }
-      if (cleanedContent.endsWith('```')) {
-        cleanedContent = cleanedContent
-            .substring(0, cleanedContent.length - 3)
-            .trim();
-      }
-    }
-
-    final decoded = jsonDecode(cleanedContent) as Map<String, dynamic>;
-    return decoded.map((k, v) => MapEntry(k, v.toString()));
   }
 }

--- a/lib/src/repositories/translation_repository.dart
+++ b/lib/src/repositories/translation_repository.dart
@@ -110,4 +110,22 @@ abstract class TranslationRepository {
         ' with identical keys.\n\n'
         '${jsonEncode(keys)}';
   }
+
+  static Map<String, String> parseTranslationsJson(String content) {
+    var cleanedContent = content.trim();
+    if (cleanedContent.startsWith('```')) {
+      final firstNewline = cleanedContent.indexOf('\n');
+      if (firstNewline != -1) {
+        cleanedContent = cleanedContent.substring(firstNewline + 1);
+      }
+      if (cleanedContent.endsWith('```')) {
+        cleanedContent = cleanedContent
+            .substring(0, cleanedContent.length - 3)
+            .trim();
+      }
+    }
+
+    final decoded = jsonDecode(cleanedContent) as Map<String, dynamic>;
+    return decoded.map((k, v) => MapEntry(k, v.toString()));
+  }
 }


### PR DESCRIPTION
## Summary

- Lifted the identical fence-stripping + JSON-decoding helper out of `AnthropicRepository` and `OpenAiRepository` into a single `TranslationRepository.parseTranslationsJson` static method.
- Matches the existing sibling-helper pattern (`getSystemPrompt`, `getUserMessage`) already hosted on `TranslationRepository`.
- Behavior-preserving — no validation, error-handling, or retry changes.

## Plan

[`docs/plan/2026-05-12-refactor-deduplicate-get-parsed-response-plan.md`](docs/plan/2026-05-12-refactor-deduplicate-get-parsed-response-plan.md)

Closes #25.

## Test plan

- [x] `fvm dart analyze` — no issues
- [x] `fvm dart format --set-exit-if-changed lib test` — clean
- [x] `fvm dart test` — 104/104 pass, including `strips markdown fences from response` cases in `anthropic_repository_test.dart` and `openai_repository_test.dart`

## Follow-ups (out of scope here)

- Optional: add direct unit tests for `parseTranslationsJson` and deduplicate the fence-stripping integration cases across both repository test files.
- Optional: doc comment on `parseTranslationsJson` (sibling helpers are also undocumented).
- Optional: revisit whether the shared static helpers should live on the exported abstract class or behind a private utility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)